### PR TITLE
Fix deployment script, block on HTML validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           ORBITER_API_KEY: ${{ secrets.ORBITER_API_KEY }}
           SOURCE: github-action
-        run: npx orbiter-cli update --siteId jrh3k5.orbiter.website -d dist
+        run: npx orbiter-cli update -d jrh3k5.orbiter.website dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,16 @@ on:
     branches: [main]
  
 jobs:
-  build:
-    uses: ./.github/workflows/build.yml
+  validate:
+    uses: ./.github/workflows/validate-html.yml
 
   deploy:
     runs-on: ubuntu-latest
-    needs: build
+    needs: validate
 
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v3
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -21,8 +21,9 @@ jobs:
           path: dist/
 
       - name: Deploy to Orbiter
-        shell: bash
-        env:
-          ORBITER_API_KEY: ${{ secrets.ORBITER_API_KEY }}
-          SOURCE: github-action
-        run: npx orbiter-cli update -d jrh3k5.orbiter.website dist
+        uses: orbiterhost/orbiter-github-actions@v0.1.4 # Update with latest version
+        with:
+          project-name: "jrh3k5.orbiter.website"
+          build-dir: "./dist"
+          api-key: ${{ secrets.ORBITER_API_KEY }}
+          node-version: "20.x"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           ORBITER_API_KEY: ${{ secrets.ORBITER_API_KEY }}
           SOURCE: github-action
-        run: npx orbiter-cli update -d jrh3k5.orbiter.website dist
+        run: npx orbiter-cli update --siteId jrh3k5.orbiter.website -d dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
+      
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/validate-html.yml
+++ b/.github/workflows/validate-html.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
I originally went with a standalone Orbiter CLI update call since this wasn't a Node project (and the GitHub action that Orbiter provides assumes it's a Node project). Now that is _is_ a Node project, let's just use the GitHub action.